### PR TITLE
Add wiki categories and layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
-.dist/
+dist/
 public/
+!public/styles.css
 output/
 .env
 .DS_Store

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,24 @@
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+  background: #0c0c0c;
+  color: #eee;
+}
+
+a {
+  color: #9ae6ff;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+nav a {
+  margin-right: 1rem;
+  font-weight: bold;
+}

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -4,12 +4,19 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>{{ title }}</title>
+  <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
-  <nav>
-    <a href="/">Home</a> |
-    <a href="/about">About</a>
-  </nav>
+  <header>
+    <h1><a href="/">Galactic Archives</a></h1>
+    <nav>
+      <a href="/professions/">Professions</a>
+      <a href="/planets/">Planets</a>
+      <a href="/factions/">Factions</a>
+      <a href="/guides/">Guides</a>
+      <a href="/lore/">Lore</a>
+    </nav>
+  </header>
   <main>
     {{ content | safe }}
   </main>

--- a/src/factions/index.md
+++ b/src/factions/index.md
@@ -1,0 +1,8 @@
+---
+layout: layout.njk
+title: Factions
+---
+
+# Factions
+
+Learn about the Galactic Civil War, player-aligned factions, and reputation systems.

--- a/src/guides/index.md
+++ b/src/guides/index.md
@@ -1,0 +1,9 @@
+---
+layout: layout.njk
+title: Guides
+---
+
+# Game Guides
+
+Player-driven tips, walkthroughs, and strategy collections.  
+Perfect for new and veteran players alike.

--- a/src/index.md
+++ b/src/index.md
@@ -5,6 +5,12 @@ title: Galactic Archives
 
 # Welcome to the Galactic Archives
 
-This is a unified knowledge base for everything **Star Wars Galaxies**.
+A unified Star Wars Galaxies knowledge hub.
 
-Stay tuned for full integration with Restoration, Fandom, and our internal intel network.
+## 🗂 Categories
+
+- [Professions](/professions/)
+- [Planets](/planets/)
+- [Factions](/factions/)
+- [Guides](/guides/)
+- [Lore](/lore/)

--- a/src/lore/index.md
+++ b/src/lore/index.md
@@ -1,0 +1,8 @@
+---
+layout: layout.njk
+title: Lore
+---
+
+# Lore
+
+Explore the rich narrative of Star Wars Galaxies — both canon and fan-made.

--- a/src/planets/index.md
+++ b/src/planets/index.md
@@ -1,0 +1,9 @@
+---
+layout: layout.njk
+title: Planets
+---
+
+# Planets
+
+Discover the worlds of SWG: from Tatooine to Mustafar.  
+We'll be adding city maps, shuttles, POIs, and quest hubs.

--- a/src/professions/index.md
+++ b/src/professions/index.md
@@ -1,0 +1,9 @@
+---
+layout: layout.njk
+title: Professions
+---
+
+# Professions
+
+Explore all the combat, support, and crafting professions in SWG.  
+Coming soon: Combat trees, skill mods, and leveling paths.


### PR DESCRIPTION
## Summary
- add navigation and styling to layout
- add homepage category links
- create index pages for Professions, Planets, Factions, Guides, and Lore
- add stylesheet and let Eleventy copy it
- ignore build output

## Testing
- `npm install`
- `npm run build`
- `npm start` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_b_6862017bad908331aa66c2051d2f3ba1