### PR TITLE
Add data directory configuration for Eleventy

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ module.exports = function(eleventyConfig) {
     dir: {
       input: "src",
       includes: "_includes",
+      data: "../data",
       output: "dist"
     },
     markdownTemplateEngine: "njk",


### PR DESCRIPTION
## Summary
- configure Eleventy to look for data files under `data/`

## Testing
- `npm run build`
- `DEBUG=Eleventy:TemplateConfig npx eleventy --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6885eb66a44483318b2adc2481d95fbf