### PR TITLE
Enable ESM configuration

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,4 @@
-module.exports = function(eleventyConfig) {
+export default function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("public");
 
   return {
@@ -11,4 +11,4 @@ module.exports = function(eleventyConfig) {
     htmlTemplateEngine: "njk",
     dataTemplateEngine: "njk"
   };
-};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "galactic-archives",
   "version": "1.0.0",
+  "type": "module",
   "description": "A unified Star Wars Galaxies knowledge hub combining official Restoration Wiki, SWG Fandom data, and exclusive resources powered by The Eye of the Galactic Beholder.",
   "main": ".eleventy.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- set `type` to `module` in `package.json`
- convert `.eleventy.js` to ES module format

## Testing
- `npm run build`
- `node scripts/import_swg_fandom.js` *(fails: ENETUNREACH)*
- `node scripts/import_swgr_restoration.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_6885ebf40e688331a3c4f75f8c320c75