### PR TITLE
Remove node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,5 @@
     "@11ty/eleventy": "^3.0.0"
   },
   "dependencies": {
-    "node-fetch": "^3.3.2"
   }
 }

--- a/scripts/import_swg_fandom.js
+++ b/scripts/import_swg_fandom.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import fetch from 'node-fetch';
 import path from 'path';
 
 const fandomBase = 'https://swg.fandom.com/wiki/';

--- a/scripts/import_swgr_restoration.js
+++ b/scripts/import_swgr_restoration.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import fetch from 'node-fetch';
 import path from 'path';
 
 const baseURL = 'https://swgr.org/wiki/';


### PR DESCRIPTION
## Summary
- use built-in `fetch` for data import scripts
- drop `node-fetch` from dependencies
- update lockfile

## Testing
- `npm install`
- `PYTHONPATH=. pytest -q` *(fails: TesseractNotFoundError and chat listener assertion)*

------
https://chatgpt.com/codex/tasks/task_b_6885f5b7f3a08331929d01214f31d5fd