### PR TITLE
Fix stylesheet path

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,7 @@
 export default function(eleventyConfig) {
-  eleventyConfig.addPassthroughCopy("public");
+  // Copy assets from `public` directly to the site root so paths like
+  // `/styles/main.css` work without the `public/` prefix.
+  eleventyConfig.addPassthroughCopy({ "public": "." });
 
   return {
     dir: {


### PR DESCRIPTION
## Summary
- ensure Eleventy copies public assets to the site root

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError / pytesseract error)*

------
https://chatgpt.com/codex/tasks/task_b_6885fbf1074883318b2253d698a98e30