### PR TITLE
Add global header

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -4,6 +4,9 @@
     {% include "head.njk" %}
   </head>
   <body>
+      <header class="site-header">
+        <h1 class="site-title"><a href="/">Galactic Archives</a></h1>
+      </header>
       <div class="layout">
         {% include "sidebar.njk" %}
         <main class="content">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6,6 +6,22 @@ body {
   padding: 0;
 }
 
+.site-header {
+  background-color: #1a1a1a;
+  padding: 1rem;
+  border-bottom: 1px solid #333;
+}
+
+.site-title a {
+  color: #80dfff;
+  text-decoration: none;
+  font-size: 1.5rem;
+}
+
+.site-title a:hover {
+  text-decoration: underline;
+}
+
 .layout {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Summary
- add site header element with link to home page
- style new site header

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688601ebefc88331a254dee07c1287a0