### PR TITLE
Add search initialization script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 public/*
+!public/search.js
 output/
 .env
 .DS_Store

--- a/public/search.js
+++ b/public/search.js
@@ -1,0 +1,17 @@
+async function initSearch() {
+  try {
+    const response = await fetch('/index.json');
+    if (!response.ok) {
+      console.error(`Failed to fetch search index: ${response.status} ${response.statusText}`);
+      return;
+    }
+    const config = await response.json();
+    if (typeof docsearch === 'function') {
+      docsearch(config);
+    }
+  } catch (err) {
+    console.error('Search initialization failed:', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initSearch);

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -5,3 +5,4 @@
 <link rel="stylesheet" href="/styles/main.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+<script type="module" src="/search.js"></script>


### PR DESCRIPTION
## Summary
- expose `public/search.js` with search initialization
- load the script in `head.njk`
- allow `public/search.js` to be committed via `.gitignore`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688651731fb48331bc7746911a96d9be