### PR TITLE
Fix search index JSON tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,8 @@ export default function(eleventyConfig) {
   // Copy assets from `public` directly to the site root
   eleventyConfig.addPassthroughCopy({ "public": "." });
 
+  eleventyConfig.addFilter("json", value => JSON.stringify(value));
+
   // Pass through compiled styles from `src/styles` so `dist/styles/main.css`
   // is generated from that directory rather than `public`.
   eleventyConfig.addPassthroughCopy({ "src/styles": "styles" });

--- a/src/search-index.json.njk
+++ b/src/search-index.json.njk
@@ -1,0 +1,13 @@
+---
+permalink: search-index.json
+eleventyExcludeFromCollections: true
+---
+[
+{% for item in collections.all %}
+  {
+    "title": {{ item.data.title | json | safe }},
+    "url": "{{ item.url }}",
+    "tags": {{ item.data.tags | json | safe }}
+  }{% if not loop.last %},{% endif %}
+{% endfor %}
+]


### PR DESCRIPTION
## Summary
- add json filter to Eleventy
- generate search index using the filter to output tag arrays

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6886525ac5fc83319974e04db2919531