### PR TITLE
Fix search index JSON output

### DIFF
--- a/dist/search-index.json
+++ b/dist/search-index.json
@@ -1,0 +1,21 @@
+[
+
+  {"title":"About","category":"Meta","tags":["about","project"],"url":"/about/"},
+
+  {"title":"Galactic Archives","category":"Home","tags":["home"],"url":"/"},
+
+  {"title":"Legacy Quest","category":"Quests","tags":["Story","Legacy","Leveling"],"url":"/content/legacy-quest/"},
+
+  {"title":"Ranger","category":"Professions","tags":["Ranged","Survival"],"url":"/content/ranger/"},
+
+  {"title":"Factions","category":"Factions","tags":["factions","overview"],"url":"/factions/"},
+
+  {"title":"Guides","category":"Guides","tags":["guides","overview"],"url":"/guides/"},
+
+  {"title":"Lore","category":"Lore","tags":["lore","overview"],"url":"/lore/"},
+
+  {"title":"Planets","category":"Planets","tags":["planets","overview"],"url":"/planets/"},
+
+  {"title":"Professions","category":"Professions","tags":["professions","overview"],"url":"/professions/"}
+
+]

--- a/src/search-index.json.njk
+++ b/src/search-index.json.njk
@@ -4,6 +4,6 @@ eleventyExcludeFromCollections: true
 ---
 [
 {% for item in collections.searchIndex %}
-  {{ item | json }}{% if not loop.last %},{% endif %}
+  {{ item | json | safe }}{% if not loop.last %},{% endif %}
 {% endfor %}
 ]


### PR DESCRIPTION
## Summary
- ensure `search-index.json` template outputs raw JSON without HTML escaping
- rebuild search index using Eleventy

## Testing
- `pytest -q`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68866a5858d0833197d8ab41780aa8a3