### PR TITLE
Handle missing search index gracefully

### DIFF
--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -1,6 +1,12 @@
 document.addEventListener("DOMContentLoaded", async () => {
-  const response = await fetch("/search-index.json");
-  const pages = await response.json();
+  let pages;
+  try {
+    const response = await fetch("/search-index.json");
+    pages = await response.json();
+  } catch (err) {
+    console.error("Failed to load search index:", err);
+    return;
+  }
 
   const fuse = new Fuse(pages, {
     keys: ["title", "category", "tags"],


### PR DESCRIPTION
## Summary
- protect search initialization with `try`/`catch`
- log failures when `search-index.json` can't be fetched

## Testing
- `pip install -q -r requirements.txt`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688671ed67008331a0cb74f32d2cf720