### PR TITLE
Make activity log path repo-relative

### DIFF
--- a/scripts/fetchActivityLog.js
+++ b/scripts/fetchActivityLog.js
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import axios from 'axios';
 import { load } from 'cheerio';
 
 const WIKI_URL = 'https://swgr.org/wiki/special/activity/';
-const OUTPUT_PATH = path.join('data', 'recent-activity.json');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = path.join(__dirname, '../data/recent-activity.json');
 
 async function fetchActivity() {
   try {


### PR DESCRIPTION
## Summary
- ensure the fetch script writes relative to repository root

## Testing
- `pytest -q`
- `node -e "import axios from '/workspace/galactic-archives/node_modules/axios/index.js';axios.get=async()=>({data:'<div class=\"mw-changeslist-title\"><a href=\"/foo\">Foo</a></div>'});import('/workspace/galactic-archives/scripts/fetchActivityLog.js');"`

------
https://chatgpt.com/codex/tasks/task_b_688677775b4c8331adc68fa6d831351e