### PR TITLE
Add npm command for activity log

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ node scripts/import_beholder_data.js <export_directory>
 Fetch recent edits from the SWGR wiki:
 
 ```bash
-node scripts/fetchActivityLog.js
+npm run fetch:activity
 ```
 
 The script writes updates to `data/recent-activity.json`. Install its dependencies with:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "eleventy",
     "import:swgr": "node scripts/import_swgr_restoration.js",
     "import:fandom": "node scripts/import_swg_fandom.js",
+    "fetch:activity": "node scripts/fetchActivityLog.js",
     "test": "jest"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- add `fetch:activity` script to run the activity log scraper
- document `npm run fetch:activity` in the Activity Monitor section of the README

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688682ece8a48331a5308254143efa43