### PR TITLE
Add robots.txt for search engine instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 public/*
+!public/robots.txt
 output/
 .env
 .DS_Store

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /internal/


### PR DESCRIPTION
## Summary
- allow `public/robots.txt` in `.gitignore`
- add `public/robots.txt` to be copied by Eleventy

## Testing
- `npm run build`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6886e81429d08331a6c597f5ac62890f