### PR TITLE
Add batch summary for internal route

### DIFF
--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -48,3 +48,11 @@ Added client-side search powered by Fuse.js for fuzzy matching across titles, ca
 Added `scripts/fetchActivityLog.js` to pull recent changes from the SWGR wiki and save them to `data/recent-activity.json`.
 
 The script uses `axios` and `cheerio` to parse titles and links from the activity page.
+
+### Batch 006 – Internal Documentation Framework
+
+Created an `/internal/` route for private pages.
+
+Introduced `internal.njk` layout that mirrors the main site but displays an `access-warning.njk` banner.
+
+Added `src/internal/ms11-status.md` to track MS11 progress; these pages use `eleventyExcludeFromCollections: true` so they stay out of the sidebar and search results.


### PR DESCRIPTION
## Summary
- document internal route setup and hidden MS11 page

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886f75cd6008331aad8ba77ce7cf903