### PR TITLE
Add pytest to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ npm run build
 
 ### Python dependencies
 
-Install the required Python packages:
+Install the required Python packages (the list includes `pytest`):
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytesseract
 Pillow
 pyautogui
+pytest


### PR DESCRIPTION
## Summary
- include `pytest` in `requirements.txt`
- mention `pytest` in Python dependency instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688700581c20833186a02e29575c9592