### PR TITLE
Add category listing pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,14 @@ export default function(eleventyConfig) {
 
   eleventyConfig.addFilter("json", value => JSON.stringify(value));
 
+  const categories = ["Professions", "Quests"];
+
+  for (const cat of categories) {
+    eleventyConfig.addCollection(cat.toLowerCase(), (collectionApi) =>
+      collectionApi.getAll().filter((item) => item.data.category === cat)
+    );
+  }
+
   eleventyConfig.addCollection("searchIndex", function (collectionApi) {
     return collectionApi.getAll().map((item) => {
       return {

--- a/src/content/professions.md
+++ b/src/content/professions.md
@@ -1,0 +1,11 @@
+---
+title: Professions
+layout: categories/index.njk
+pagination:
+  data: collections.professions
+  size: 1000
+  alias: items
+permalink: "/professions/"
+eleventyComputed:
+  category: "Professions"
+---

--- a/src/content/quests.md
+++ b/src/content/quests.md
@@ -1,0 +1,11 @@
+---
+title: Quests
+layout: categories/index.njk
+pagination:
+  data: collections.quests
+  size: 1000
+  alias: items
+permalink: "/quests/"
+eleventyComputed:
+  category: "Quests"
+---

--- a/src/layouts/categories/index.njk
+++ b/src/layouts/categories/index.njk
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include "head.njk" %}
+  </head>
+  <body>
+    <div class="layout">
+      {% include "sidebar.njk" %}
+      <main class="content">
+        <h1>{{ title }}</h1>
+        <ul class="category-list">
+          {% for item in items %}
+            <li>
+              <a href="{{ item.url }}">{{ item.data.title }}</a>
+              <span class="tag">{{ item.data.tags | join(', ') }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      </main>
+    </div>
+  </body>
+</html>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -124,3 +124,20 @@ a:hover {
   border-left: 3px solid #00bfff;
   border-radius: 4px;
 }
+
+.category-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.category-list li {
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.category-list .tag {
+  font-size: 0.8rem;
+  color: #aaa;
+}


### PR DESCRIPTION
## Summary
- add dynamic category collections in `.eleventy.js`
- create `categories/index.njk` layout for listing pages
- add virtual pages for `/professions/` and `/quests/`
- style new lists in `main.css`

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6887046aa2b88331b4469ec47a6ca4b1