### PR TITLE
Fix duplicate permalink for professions overview

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -13,7 +13,7 @@ A unified Star Wars Galaxies knowledge hub.
 
 ## 🗂 Categories
 
-- [Professions](/professions/)
+- [Professions](/professions/overview/)
 - [Planets](/planets/)
 - [Factions](/factions/)
 - [Guides](/guides/)

--- a/src/professions/overview.md
+++ b/src/professions/overview.md
@@ -5,6 +5,7 @@ category: Professions
 tags:
   - professions
   - overview
+permalink: "/professions/overview/"
 last_updated: 2025-07-27
 ---
 


### PR DESCRIPTION
## Summary
- rename `src/professions/index.md` to `src/professions/overview.md`
- add an explicit permalink
- update the home page link to the overview

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6887a8fe04e48331ad0f853021fade7f