### PR TITLE
Fix tag display when tags are missing

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -13,7 +13,7 @@
           <h1>{{ title }}</h1>
           <p class="page-meta">
             <strong>Category:</strong> {{ category }} |
-            <strong>Tags:</strong> {{ tags | join(', ') }} |
+            <strong>Tags:</strong> {{ tags | default([]) | join(', ') }} |
             <em>Last updated: {{ last_updated }}</em>
           </p>
         </header>

--- a/src/layouts/categories/index.njk
+++ b/src/layouts/categories/index.njk
@@ -12,7 +12,7 @@
           {% for item in items %}
             <li>
               <a href="{{ item.url }}">{{ item.data.title }}</a>
-              <span class="tag">{{ item.data.tags | join(', ') }}</span>
+              <span class="tag">{{ item.data.tags | default([]) | join(', ') }}</span>
             </li>
           {% endfor %}
         </ul>

--- a/src/layouts/internal.njk
+++ b/src/layouts/internal.njk
@@ -14,7 +14,7 @@
           <h1>{{ title }}</h1>
           <p class="page-meta">
             <strong>Category:</strong> {{ category }} |
-            <strong>Tags:</strong> {{ tags | join(', ') }} |
+            <strong>Tags:</strong> {{ tags | default([]) | join(', ') }} |
             <em>Last updated: {{ last_updated }}</em>
           </p>
         </header>


### PR DESCRIPTION
## Summary
- avoid errors when rendering pages with no tags
- fix base, internal, and category index templates to default tags to an empty list

## Testing
- `npm test`
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6887aa31dd348331afd6493c001797c1