### PR TITLE
Update category docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,7 @@ pytest
 ## Internal Routes
 
 The site includes a private `/internal/` section used for team-only resources. Pages in this directory set `eleventyExcludeFromCollections: true`, so they remain hidden from generated indexes. Search engines are also instructed not to crawl these routes via the `Disallow: /internal/` rule in [`public/robots.txt`](public/robots.txt).
+
+## Categories
+
+Eleventy scans every Markdown file for a `category` value in its front matter and builds a collection for each unique category. Listing pages like `/professions/` and `/quests/` use the `categories/index.njk` layout to display these collections. When you add `category: MyCategory` to a page, it automatically shows up on `/mycategory/` if that listing page exists.

--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -63,4 +63,4 @@ Added `categories/index.njk` layout to display lists of items within a category.
 
 Created `professions.md` and `quests.md` in `src/content` to show the Professions and Quests collections using pagination.
 
-Updated `.eleventy.js` to generate `professions` and `quests` collections by filtering items by their `category` value.
+Updated `.eleventy.js` to automatically discover categories from front matter and generate collections for each one.


### PR DESCRIPTION
## Summary
- revise Batch 007 notes to mention automatic category discovery
- document how category metadata populates listing pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887aae4ae208331b331230295b30676