### PR TITLE
Slugify Eleventy collection keys

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,7 +27,8 @@ export default function (eleventyConfig) {
   }
 
   for (const cat of categories) {
-    eleventyConfig.addCollection(cat.toLowerCase(), (collectionApi) =>
+    const key = cat.toLowerCase().replace(/\s+/g, '-');
+    eleventyConfig.addCollection(key, (collectionApi) =>
       collectionApi
         .getAll()
         .filter((item) => item.data.category === cat)

--- a/tests/eleventyCollections.test.js
+++ b/tests/eleventyCollections.test.js
@@ -14,8 +14,10 @@ test('professions and quests collections filter items by category', () => {
   // Load Eleventy configuration which registers collections
   eleventyConfigFn(mockConfig);
 
-  expect(collections).toHaveProperty('professions');
-  expect(collections).toHaveProperty('quests');
+  const slugify = (cat) => cat.toLowerCase().replace(/\s+/g, '-');
+
+  expect(collections).toHaveProperty(slugify('Professions'));
+  expect(collections).toHaveProperty(slugify('Quests'));
 
   const items = [
     { data: { category: 'Professions', title: 'Ranger' } },
@@ -26,8 +28,8 @@ test('professions and quests collections filter items by category', () => {
     getAll: () => items
   };
 
-  const professions = collections.professions(collectionApi);
-  const quests = collections.quests(collectionApi);
+  const professions = collections[slugify('Professions')](collectionApi);
+  const quests = collections[slugify('Quests')](collectionApi);
 
   expect(professions.map(i => i.data.title)).toEqual(['Ranger', 'Medic']);
   expect(quests.map(i => i.data.title)).toEqual(['Legacy Quest']);


### PR DESCRIPTION
## Summary
- generate Eleventy collection names using slugified categories
- adapt tests to check for slugified names

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_6887ad1ef0948331a4dbdcb565e4b983