### PR TITLE
Sort category items alphabetically

### DIFF
--- a/src/layouts/categories/index.njk
+++ b/src/layouts/categories/index.njk
@@ -9,7 +9,7 @@
       <main class="content">
         <h1>{{ title }}</h1>
         <ul class="category-list">
-          {% for item in items %}
+          {% for item in items | sort(attribute='data.title') %}
             <li>
               <a href="{{ item.url }}">{{ item.data.title }}</a>
               <span class="tag">{{ item.data.tags | default([]) | join(', ') }}</span>


### PR DESCRIPTION
## Summary
- ensure category listing template sorts items by title

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6887b02aa9d0833190fb38a16e2343c4