### PR TITLE
Fix slugifyCategory regex

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,7 +3,10 @@ import fs from "fs";
 import matter from "gray-matter";
 
 function slugifyCategory(name) {
-  return name.toLowerCase().replace(/\s+/g, "-");
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
 }
 
 export default function (eleventyConfig) {

--- a/tests/eleventyCollections.test.js
+++ b/tests/eleventyCollections.test.js
@@ -31,4 +31,7 @@ test('professions and quests collections filter items by category', () => {
 
   expect(professions.map(i => i.data.title)).toEqual(['Ranger', 'Medic']);
   expect(quests.map(i => i.data.title)).toEqual(['Legacy Quest']);
+
+  // Punctuation is removed when slugifying categories
+  expect(slugifyCategory('Lore & Legends!')).toBe('lore-legends');
 });


### PR DESCRIPTION
## Summary
- broaden slugifyCategory to strip punctuation
- verify punctuation removal in eleventy collection tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887b43033888331839710b5e99c5258