### PR TITLE
Fix category listing pages to not index themselves

### DIFF
--- a/src/content/professions.md
+++ b/src/content/professions.md
@@ -6,6 +6,7 @@ pagination:
   size: 1000
   alias: items
 permalink: "/professions/"
+eleventyExcludeFromCollections: true
 eleventyComputed:
   category: "Professions"
 ---

--- a/src/content/quests.md
+++ b/src/content/quests.md
@@ -6,6 +6,7 @@ pagination:
   size: 1000
   alias: items
 permalink: "/quests/"
+eleventyExcludeFromCollections: true
 eleventyComputed:
   category: "Quests"
 ---


### PR DESCRIPTION
## Summary
- prevent `/professions/` from appearing in collections
- prevent `/quests/` from appearing in collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887bb5595608331ba7683e4df6165ff