### PR TITLE
Insert search box and breadcrumbs into category layout

### DIFF
--- a/src/layouts/categories/index.njk
+++ b/src/layouts/categories/index.njk
@@ -7,6 +7,8 @@
     <div class="layout">
       {% include "sidebar.njk" %}
       <main class="content">
+        {% include "searchbox.njk" %}
+        {% include "breadcrumbs.njk" %}
         <h1>{{ title }}</h1>
         <ul class="category-list">
           {% for item in items | sort(attribute='data.title') %}


### PR DESCRIPTION
## Summary
- display search box and breadcrumbs in the category index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6887c16591a48331802db0caa7412196