### PR TITLE
Filter excluded pages from search index

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -48,14 +48,17 @@ export default function (eleventyConfig) {
   }
 
   eleventyConfig.addCollection("searchIndex", function (collectionApi) {
-    return collectionApi.getAll().map((item) => {
-      return {
-        title: item.data.title,
-        category: item.data.category,
-        tags: item.data.tags,
-        url: item.url
-      };
-    });
+    return collectionApi
+      .getAll()
+      .filter((item) => item.data.eleventyExcludeFromCollections !== true)
+      .map((item) => {
+        return {
+          title: item.data.title,
+          category: item.data.category,
+          tags: item.data.tags,
+          url: item.url,
+        };
+      });
   });
 
   // Pass through compiled styles from `src/styles` so `dist/styles/main.css`

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pytest
 
 ## Internal Routes
 
-The site includes a private `/internal/` section used for team-only resources. Pages in this directory set `eleventyExcludeFromCollections: true`, so they remain hidden from generated indexes. Search engines are also instructed not to crawl these routes via the `Disallow: /internal/` rule in [`public/robots.txt`](public/robots.txt).
+The site includes a private `/internal/` section used for team-only resources. Pages in this directory set `eleventyExcludeFromCollections: true`, so they remain hidden from generated indexes. Search engines are also instructed not to crawl these routes via the `Disallow: /internal/` rule in [`public/robots.txt`](public/robots.txt). The search index honors this flag as well.
 
 ## Categories
 

--- a/tests/searchIndex.test.js
+++ b/tests/searchIndex.test.js
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+import eleventyConfigFn from '../.eleventy.js';
+
+test('search index excludes eleventyExcludeFromCollections items', () => {
+  const collections = {};
+  const mockConfig = {
+    addPassthroughCopy: jest.fn(),
+    addFilter: jest.fn(),
+    addCollection: (name, fn) => {
+      collections[name] = fn;
+    },
+  };
+
+  eleventyConfigFn(mockConfig);
+
+  const items = [
+    { data: { title: 'Visible', eleventyExcludeFromCollections: false } , url: '/visible/' },
+    { data: { title: 'Hidden', eleventyExcludeFromCollections: true }, url: '/hidden/' },
+  ];
+
+  const collectionApi = {
+    getAll: () => items,
+  };
+
+  const result = collections['searchIndex'](collectionApi);
+  expect(result).toEqual([
+    {
+      title: 'Visible',
+      category: undefined,
+      tags: undefined,
+      url: '/visible/',
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- filter out `eleventyExcludeFromCollections` items when creating the search index
- document that the search index respects this flag
- test that excluded pages are missing from the search index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887c4186a988331a145bbe73a4c0dab