### PR TITLE
Fix breadcrumbs links for categories

### DIFF
--- a/src/_includes/breadcrumbs.njk
+++ b/src/_includes/breadcrumbs.njk
@@ -1,5 +1,5 @@
 <nav class="breadcrumbs">
   <a href="/">Home</a> /
-  <a href="/{{ category | lower }}/">{{ category }}</a> /
+  <a href="/{{ category | categorySlug }}/">{{ category }}</a> /
   <span>{{ title }}</span>
 </nav>


### PR DESCRIPTION
## Summary
- use the `categorySlug` filter in `src/_includes/breadcrumbs.njk`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6887c897def883318ca3b925e6fd5683