### PR TITLE
Fix homepage category exclusion

### DIFF
--- a/src/layouts/homepage.njk
+++ b/src/layouts/homepage.njk
@@ -12,7 +12,9 @@
           {# Build a unique list of categories from all pages #}
           {% set categories = [] %}
           {% for page in collections.all %}
-            {% if page.data.category and categories.indexOf(page.data.category) == -1 %}
+            {% if page.data.category
+                and page.data.eleventyExcludeFromCollections !== true
+                and categories.indexOf(page.data.category) == -1 %}
               {% set _ = categories.push(page.data.category) %}
             {% endif %}
           {% endfor %}

--- a/tests/homepageCategories.test.js
+++ b/tests/homepageCategories.test.js
@@ -1,0 +1,26 @@
+import nunjucks from 'nunjucks';
+import fs from 'fs';
+import { slugifyCategory } from '../.eleventy.js';
+
+class NullLoader extends nunjucks.Loader {
+  getSource(name) {
+    return { src: '', path: name, noCache: true };
+  }
+}
+
+test('homepage category list excludes eleventyExcludeFromCollections pages', () => {
+  const tpl = fs.readFileSync('src/layouts/homepage.njk', 'utf8');
+  const env = new nunjucks.Environment(new NullLoader());
+  env.addFilter('categorySlug', slugifyCategory);
+  const html = env.renderString(tpl, {
+    title: 'Test',
+    collections: {
+      all: [
+        { data: { category: 'Visible' } },
+        { data: { category: 'Hidden', eleventyExcludeFromCollections: true } }
+      ]
+    }
+  });
+  expect(html).toContain('<a href="/visible/">Visible</a>');
+  expect(html).not.toContain('Hidden');
+});


### PR DESCRIPTION
## Summary
- filter out eleventyExcludeFromCollections pages when gathering homepage categories
- test that excluded pages are not shown in the category grid

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6887d7aa6c5c83319879e376b51205c9