### PR TITLE
Fix category scanning for Eleventy collections

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,7 +29,11 @@ export default function (eleventyConfig) {
   const categories = new Set();
   for (const file of files) {
     const { data } = matter(fs.readFileSync(file, "utf-8"));
-    if (data && data.category) {
+    if (
+      data &&
+      data.category &&
+      data.eleventyExcludeFromCollections !== true
+    ) {
       categories.add(data.category);
     }
   }

--- a/tests/eleventyCollections.test.js
+++ b/tests/eleventyCollections.test.js
@@ -59,3 +59,19 @@ test('category collections exclude items flagged eleventyExcludeFromCollections'
   const professions = collections[slugifyCategory('Professions')](collectionApi);
   expect(professions.map(i => i.data.title)).toEqual(['Smuggler']);
 });
+
+test('categories from excluded files are not added to collections', () => {
+  const collections = {};
+  const mockConfig = {
+    addPassthroughCopy: jest.fn(),
+    addFilter: jest.fn(),
+    addCollection: (name, fn) => {
+      collections[name] = fn;
+    }
+  };
+
+  eleventyConfigFn(mockConfig);
+
+  expect(collections).not.toHaveProperty(slugifyCategory('Home'));
+  expect(collections).not.toHaveProperty(slugifyCategory('Internal'));
+});


### PR DESCRIPTION
## Summary
- ignore excluded markdown files when gathering categories
- test that excluded categories do not create collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887db8dc68483319c63d8a6a57ab93b