### PR TITLE
Use slug filter for category links

### DIFF
--- a/src/layouts/homepage.njk
+++ b/src/layouts/homepage.njk
@@ -18,7 +18,8 @@
             {% if cat and not (cat in seen) and page.data.eleventyExcludeFromCollections != true %}
               {% set _ = seen.push(cat) %}
               <li>
-                <a href="/{{ cat | lower }}/">{{ cat }}</a>
+                <!-- Use the slugified category for the URL -->
+                <a href="/{{ cat | categorySlug }}/">{{ cat }}</a>
               </li>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
## Summary
- use `categorySlug` filter on homepage category links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6887e06052188331ace26667d47c14bf