### PR TITLE
Add content classification script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ These values are loaded automatically when running the script.
 
 Parsed data is stored in `/data/raw`, to be transformed later by custom loaders.
 
+## Content Classification
+
+Run `npm run classify` to execute the hybrid rule+AI classifier. The script reads from `data/sample-hint.md` and writes metadata to `classified/sample-hint.json`.
+
 ## Development
 
 Start a local development server:


### PR DESCRIPTION
## Summary
- document rule + AI classifier script in README

## Testing
- `npm test --silent`
- `npm run classify --silent`

------
https://chatgpt.com/codex/tasks/task_b_6887f8f725b48331abc8f006133944e1