### PR TITLE
Add classifier test

### DIFF
--- a/scripts/classifyContent.js
+++ b/scripts/classifyContent.js
@@ -5,11 +5,9 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Load raw markdown
+// Paths used when running the script directly
 const INPUT_PATH = path.join(__dirname, '../data/sample-hint.md');
 const OUTPUT_PATH = path.join(__dirname, '../classified/sample-hint.json');
-
-const raw = fs.readFileSync(INPUT_PATH, 'utf8');
 
 // Rule-based categories
 const rules = [
@@ -45,20 +43,28 @@ function fallbackAIMockClassifier(text) {
   };
 }
 
-// Classify input
-let classification = ruleBasedClassifier(raw);
-if (!classification) {
-  classification = fallbackAIMockClassifier(raw);
+export function classifyContent(text) {
+  let classification = ruleBasedClassifier(text);
+  if (!classification) {
+    classification = fallbackAIMockClassifier(text);
+  }
+  return classification;
 }
 
-// Build metadata block
-const metadata = {
-  title: 'Sample Hint',
-  classified_at: new Date().toISOString(),
-  ...classification
-};
+export { ruleBasedClassifier, fallbackAIMockClassifier };
 
-fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
-fs.writeFileSync(OUTPUT_PATH, JSON.stringify(metadata, null, 2));
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const raw = fs.readFileSync(INPUT_PATH, 'utf8');
+  const classification = classifyContent(raw);
 
-console.log('✅ Classified:', metadata);
+  const metadata = {
+    title: 'Sample Hint',
+    classified_at: new Date().toISOString(),
+    ...classification
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(metadata, null, 2));
+
+  console.log('✅ Classified:', metadata);
+}

--- a/tests/classifyContent.test.js
+++ b/tests/classifyContent.test.js
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals';
+
+// Mock fs to ensure no real file operations occur when importing the module
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => ''),
+    writeFileSync: jest.fn(),
+    mkdirSync: jest.fn(),
+  }
+}));
+
+let classifyContent, ruleBasedClassifier, fallbackAIMockClassifier;
+
+beforeAll(async () => {
+  const mod = await import('../scripts/classifyContent.js');
+  classifyContent = mod.classifyContent;
+  ruleBasedClassifier = mod.ruleBasedClassifier;
+  fallbackAIMockClassifier = mod.fallbackAIMockClassifier;
+});
+
+describe('classifyContent', () => {
+  test('rule-based match returns Quests category', () => {
+    const result = classifyContent('You must kill the beast');
+    expect(result).toEqual({
+      source: 'rules',
+      category: 'Quests',
+      tags: ['Combat'],
+      ms11_priority: 'Medium'
+    });
+  });
+
+  test('fallback classification used when no rules match', () => {
+    const result = classifyContent('Just explore the world');
+    expect(result).toEqual({
+      source: 'ai-fallback',
+      category: 'Exploration',
+      tags: ['Planet', 'Navigation'],
+      ms11_priority: 'Low'
+    });
+  });
+
+  test('ruleBasedClassifier returns null when no rule matches', () => {
+    expect(ruleBasedClassifier('random text')).toBeNull();
+  });
+
+  test('fallbackAIMockClassifier returns exploration classification', () => {
+    expect(fallbackAIMockClassifier('anything')).toEqual({
+      source: 'ai-fallback',
+      category: 'Exploration',
+      tags: ['Planet', 'Navigation'],
+      ms11_priority: 'Low'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- export classification helpers and CLI guard
- add Jest tests for the content classifier

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_688807cdbf54833192ed9b9e0ce21df9