### PR TITLE
Add CLI args to classifyContent script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Parsed data is stored in `/data/raw`, to be transformed later by custom loaders.
 
 ## Content Classification
 
-Run `npm run classify` to execute the hybrid rule+AI classifier. The script reads from `data/sample-hint.md` and writes metadata to `classified/sample-hint.json`.
+Run `npm run classify` to execute the hybrid rule+AI classifier. By default the script reads from `data/sample-hint.md` and writes metadata to `classified/sample-hint.json`. When running it manually you can override these paths with `--input <file>` and `--output <file>`.
 
 ## Development
 

--- a/scripts/classifyContent.js
+++ b/scripts/classifyContent.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Paths used when running the script directly
+// Default paths used when running the script directly
 const INPUT_PATH = path.join(__dirname, '../data/sample-hint.md');
 const OUTPUT_PATH = path.join(__dirname, '../classified/sample-hint.json');
 
@@ -54,7 +54,16 @@ export function classifyContent(text) {
 export { ruleBasedClassifier, fallbackAIMockClassifier };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const raw = fs.readFileSync(INPUT_PATH, 'utf8');
+  const args = process.argv.slice(2);
+  const getArg = (flag, defaultVal) => {
+    const idx = args.indexOf(flag);
+    return idx !== -1 && args[idx + 1] ? args[idx + 1] : defaultVal;
+  };
+
+  const inputPath = getArg('--input', INPUT_PATH);
+  const outputPath = getArg('--output', OUTPUT_PATH);
+
+  const raw = fs.readFileSync(inputPath, 'utf8');
   const classification = classifyContent(raw);
 
   const metadata = {
@@ -63,8 +72,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     ...classification
   };
 
-  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
-  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(metadata, null, 2));
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, JSON.stringify(metadata, null, 2));
 
   console.log('✅ Classified:', metadata);
 }


### PR DESCRIPTION
## Summary
- add `--input` and `--output` options to `classifyContent.js`
- document new options in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68880b97b56083319f1cd9cbdc6385e0