### PR TITLE
Add testing notes and Makefile helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: deps
+
+deps:
+	pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ npm install
 pip install -r requirements.txt
 ```
 
+You can also install the Python packages via `make deps`.
+
 These steps are required prior to using `npm test` or `pytest`.
 
 ## Data Import
@@ -86,17 +88,21 @@ npm run build
 
 ### Python dependencies
 
-Install the required Python packages (the list includes `pytest`):
+Install the required Python packages:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-After installation, run the test suite:
+## Testing
+
+Run the test suite with:
 
 ```bash
 pytest
 ```
+
+Be sure to install dependencies first by running `pip install -r requirements.txt`.
 
 ## Internal Routes
 


### PR DESCRIPTION
## Summary
- mention `make deps` in setup instructions
- add a new Testing section describing how to run `pytest`
- include a simple Makefile target to install Python dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68880c39f4d08331a0bed5a5125e9562