### PR TITLE
Add online activity fetch and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ parses `data/sample-activity.html`. Run the script directly with:
 node scripts/fetchActivityLog.js
 ```
 
-Set `USE_OFFLINE_MODE=false` to fetch live data from the wiki instead.
+Set `USE_OFFLINE_MODE=false` to fetch live data from the wiki instead. When this
+flag is disabled the script calls an asynchronous `fetchActivityOnline()`
+function that downloads the page defined by `WIKI_URL` using `fetch`.
 
 You can also override the default wiki URL or output location. Copy `.env.example` to `.env` and update the values:
 

--- a/scripts/fetchActivityLog.js
+++ b/scripts/fetchActivityLog.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const USE_OFFLINE_MODE = process.env.USE_OFFLINE_MODE !== 'false';
+const WIKI_URL = process.env.WIKI_URL || 'https://swgr.org/wiki/special/activity/';
 const SAMPLE_PATH = path.join(__dirname, '../data/sample-activity.html');
 const OUTPUT_PATH = process.env.OUTPUT_PATH || path.join(__dirname, '../data/recent-activity.json');
 
@@ -35,8 +36,38 @@ export function fetchActivityOffline() {
   }
 }
 
+export async function fetchActivityOnline() {
+  try {
+    const res = await fetch(WIKI_URL);
+    const html = await res.text();
+    const $ = load(html);
+    const changes = [];
+
+    $('.mw-changeslist-title').each((_, el) => {
+      const link = $(el).find('a').attr('href');
+      const title = $(el).text().trim();
+      if (title && link) {
+        changes.push({
+          title,
+          link: `https://swgr.org${link}`,
+          timestamp: new Date().toISOString()
+        });
+      }
+    });
+
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(changes, null, 2));
+    console.log(`✅ Updated ${changes.length} items to recent-activity.json`);
+  } catch (err) {
+    console.error('❌ Failed to fetch activity log:', err);
+  }
+}
+
 export { OUTPUT_PATH, USE_OFFLINE_MODE };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  fetchActivityOffline();
+  if (USE_OFFLINE_MODE) {
+    fetchActivityOffline();
+  } else {
+    await fetchActivityOnline();
+  }
 }

--- a/tests/fetchActivityLog.test.js
+++ b/tests/fetchActivityLog.test.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { jest } from '@jest/globals';
 
 import { fetchActivityOffline, OUTPUT_PATH } from '../scripts/fetchActivityLog.js';
 
@@ -41,5 +42,37 @@ test('fetchActivityOffline writes expected JSON', () => {
       timestamp: expect.any(String)
     }
   ]);
+});
+
+test('USE_OFFLINE_MODE=false triggers online fetch', async () => {
+  const html = fs.readFileSync(path.join(__dirname, '../data/sample-activity.html'), 'utf-8');
+  const fetchMock = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(html) }));
+  const originalFetch = global.fetch;
+  global.fetch = fetchMock;
+
+  process.env.USE_OFFLINE_MODE = 'false';
+  process.env.WIKI_URL = 'https://example.com/activity/';
+
+  const moduleUrl = new URL('../scripts/fetchActivityLog.js', import.meta.url);
+  moduleUrl.search = `?t=${Date.now()}`;
+  const mod = await import(moduleUrl.href);
+  await mod.fetchActivityOnline();
+
+  expect(fetchMock).toHaveBeenCalled();
+  const data = JSON.parse(fs.readFileSync(mod.OUTPUT_PATH, 'utf-8'));
+  expect(data).toEqual([
+    {
+      title: 'Legacy Quest',
+      link: 'https://swgr.org/wiki/legacy/',
+      timestamp: expect.any(String)
+    },
+    {
+      title: 'Ranger',
+      link: 'https://swgr.org/wiki/ranger/',
+      timestamp: expect.any(String)
+    }
+  ]);
+
+  global.fetch = originalFetch;
 });
 


### PR DESCRIPTION
## Summary
- support fetching wiki activity online with fetch
- switch CLI logic to use online mode when USE_OFFLINE_MODE=false
- test the new fetchActivityOnline function
- document USE_OFFLINE_MODE and new online fetch flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888621d4eec8331a198accd4ebf5603