### PR TITLE
Add live wiki URL support to fetchActivityLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ parses `data/sample-activity.html`. Run the script directly with:
 node scripts/fetchActivityLog.js
 ```
 
-Set `USE_OFFLINE_MODE=false` to fetch live data from the wiki instead.
+Set `USE_OFFLINE_MODE=false` to fetch live data from the wiki instead. The URL is read from the `WIKI_URL` environment variable.
 
 You can also override the default wiki URL or output location. Copy `.env.example` to `.env` and update the values:
 

--- a/scripts/fetchActivityLog.js
+++ b/scripts/fetchActivityLog.js
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const USE_OFFLINE_MODE = process.env.USE_OFFLINE_MODE !== 'false';
 const SAMPLE_PATH = path.join(__dirname, '../data/sample-activity.html');
 const OUTPUT_PATH = process.env.OUTPUT_PATH || path.join(__dirname, '../data/recent-activity.json');
+const WIKI_URL = process.env.WIKI_URL || 'https://swgr.org/wiki/special/activity/';
 
 export function fetchActivityOffline() {
   try {
@@ -35,8 +36,40 @@ export function fetchActivityOffline() {
   }
 }
 
-export { OUTPUT_PATH, USE_OFFLINE_MODE };
+export async function fetchActivityOnline() {
+  try {
+    const response = await fetch(WIKI_URL);
+    const html = await response.text();
+    const $ = load(html);
+    const changes = [];
+
+    const base = new URL(WIKI_URL).origin;
+
+    $('.mw-changeslist-title').each((_, el) => {
+      const link = $(el).find('a').attr('href');
+      const title = $(el).text().trim();
+      if (title && link) {
+        changes.push({
+          title,
+          link: `${base}${link}`,
+          timestamp: new Date().toISOString()
+        });
+      }
+    });
+
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(changes, null, 2));
+    console.log(`✅ Updated ${changes.length} items to recent-activity.json`);
+  } catch (err) {
+    console.error('❌ Failed to fetch activity log:', err);
+  }
+}
+
+export { OUTPUT_PATH, USE_OFFLINE_MODE, WIKI_URL };
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  fetchActivityOffline();
+  if (USE_OFFLINE_MODE) {
+    fetchActivityOffline();
+  } else {
+    fetchActivityOnline();
+  }
 }

--- a/tests/fetchActivityLog.test.js
+++ b/tests/fetchActivityLog.test.js
@@ -1,14 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-
-import { fetchActivityOffline, OUTPUT_PATH } from '../scripts/fetchActivityLog.js';
+import { jest } from '@jest/globals';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = path.join(__dirname, '../data/recent-activity.json');
 
 let original;
+let envWiki;
+let envMode;
 
 beforeEach(() => {
+  envWiki = process.env.WIKI_URL;
+  envMode = process.env.USE_OFFLINE_MODE;
   if (fs.existsSync(OUTPUT_PATH)) {
     original = fs.readFileSync(OUTPUT_PATH, 'utf-8');
     fs.unlinkSync(OUTPUT_PATH);
@@ -18,6 +22,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  process.env.WIKI_URL = envWiki;
+  process.env.USE_OFFLINE_MODE = envMode;
   if (original) {
     fs.writeFileSync(OUTPUT_PATH, original);
   } else if (fs.existsSync(OUTPUT_PATH)) {
@@ -25,7 +31,10 @@ afterEach(() => {
   }
 });
 
-test('fetchActivityOffline writes expected JSON', () => {
+// Offline mode
+test('fetchActivityOffline writes expected JSON', async () => {
+  jest.resetModules();
+  const { fetchActivityOffline } = await import('../scripts/fetchActivityLog.js');
   fetchActivityOffline();
   const content = fs.readFileSync(OUTPUT_PATH, 'utf-8');
   const data = JSON.parse(content);
@@ -43,3 +52,33 @@ test('fetchActivityOffline writes expected JSON', () => {
   ]);
 });
 
+// Online mode with custom URL
+test('fetchActivityOnline uses custom WIKI_URL', async () => {
+  process.env.WIKI_URL = 'http://example.com/activity';
+  jest.resetModules();
+  const { fetchActivityOnline } = await import('../scripts/fetchActivityLog.js');
+  const html = fs.readFileSync(path.join(__dirname, '../data/sample-activity.html'), 'utf-8');
+  const fetchMock = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(html) }));
+  const originalFetch = global.fetch;
+  global.fetch = fetchMock;
+
+  await fetchActivityOnline();
+
+  const content = fs.readFileSync(OUTPUT_PATH, 'utf-8');
+  const data = JSON.parse(content);
+  expect(fetchMock).toHaveBeenCalledWith('http://example.com/activity');
+  expect(data).toEqual([
+    {
+      title: 'Legacy Quest',
+      link: 'http://example.com/wiki/legacy/',
+      timestamp: expect.any(String)
+    },
+    {
+      title: 'Ranger',
+      link: 'http://example.com/wiki/ranger/',
+      timestamp: expect.any(String)
+    }
+  ]);
+
+  global.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- support custom `WIKI_URL` when fetching activity online
- document the `WIKI_URL` variable in README live mode instructions
- test online fetch with overridden `WIKI_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888d3ba9efc8331952601eef7553c6a