### PR TITLE
Support custom wiki URL for activity log

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ node scripts/fetchActivityLog.js
 
 Set `USE_OFFLINE_MODE=false` to fetch live data from the wiki instead. When this
 flag is disabled the script calls an asynchronous `fetchActivityOnline()`
-function that downloads the page defined by `WIKI_URL` using `fetch`.
+function that downloads the page defined by `WIKI_URL` using `fetch`. You can
+override this endpoint by setting the `WIKI_URL` environment variable.
 
 You can also override the default wiki URL or output location. Copy `.env.example` to `.env` and update the values:
 

--- a/scripts/fetchActivityLog.js
+++ b/scripts/fetchActivityLog.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const USE_OFFLINE_MODE = process.env.USE_OFFLINE_MODE !== 'false';
-const WIKI_URL = process.env.WIKI_URL || 'https://swgr.org/wiki/special/activity/';
+const DEFAULT_WIKI_URL = 'https://swgr.org/wiki/special/activity/';
 const SAMPLE_PATH = path.join(__dirname, '../data/sample-activity.html');
 const OUTPUT_PATH = process.env.OUTPUT_PATH || path.join(__dirname, '../data/recent-activity.json');
 
@@ -21,9 +21,10 @@ export function fetchActivityOffline() {
       const link = $(el).find('a').attr('href');
       const title = $(el).text().trim();
       if (title && link) {
+        const baseUrl = process.env.WIKI_URL || DEFAULT_WIKI_URL;
         changes.push({
           title,
-          link: `https://swgr.org${link}`,
+          link: new URL(link, baseUrl).href,
           timestamp: new Date().toISOString()
         });
       }
@@ -38,7 +39,8 @@ export function fetchActivityOffline() {
 
 export async function fetchActivityOnline() {
   try {
-    const res = await fetch(WIKI_URL);
+    const wikiUrl = process.env.WIKI_URL || DEFAULT_WIKI_URL;
+    const res = await fetch(wikiUrl);
     const html = await res.text();
     const $ = load(html);
     const changes = [];
@@ -49,7 +51,7 @@ export async function fetchActivityOnline() {
       if (title && link) {
         changes.push({
           title,
-          link: `https://swgr.org${link}`,
+          link: new URL(link, wikiUrl).href,
           timestamp: new Date().toISOString()
         });
       }

--- a/tests/fetchActivityLog.test.js
+++ b/tests/fetchActivityLog.test.js
@@ -58,17 +58,17 @@ test('USE_OFFLINE_MODE=false triggers online fetch', async () => {
   const mod = await import(moduleUrl.href);
   await mod.fetchActivityOnline();
 
-  expect(fetchMock).toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalledWith('https://example.com/activity/');
   const data = JSON.parse(fs.readFileSync(mod.OUTPUT_PATH, 'utf-8'));
   expect(data).toEqual([
     {
       title: 'Legacy Quest',
-      link: 'https://swgr.org/wiki/legacy/',
+      link: 'https://example.com/wiki/legacy/',
       timestamp: expect.any(String)
     },
     {
       title: 'Ranger',
-      link: 'https://swgr.org/wiki/ranger/',
+      link: 'https://example.com/wiki/ranger/',
       timestamp: expect.any(String)
     }
   ]);


### PR DESCRIPTION
## Summary
- allow `fetchActivityLog` to read `WIKI_URL` at runtime
- generate item links using that URL
- document the env var in README
- test using a custom `WIKI_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6888d5e938808331ae4e3caef5ff1883