### PR TITLE
Document JSON API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,12 @@ Eleventy scans every Markdown file for a `category` value in its front matter an
 
 ## JSON API
 
-Two JSON endpoints expose the raw Profession and Quest data used to build the category pages. They live under `/api/professions.json` and `/api/quests.json`.
+Use the following endpoints to access the raw Profession and Quest data generated for the site:
 
-These files are generated at build time and include all processed entries. Because they are intended for programmatic access only, they are marked with `eleventyExcludeFromCollections: true` so the links never appear in navigation menus or the search index.
+- `/api/professions.json`
+- `/api/quests.json`
+
+These files are produced at build time and flagged with `eleventyExcludeFromCollections: true` so they stay off the main navigation and out of the search index.
 
 Example usage with `fetch`:
 

--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -79,9 +79,7 @@ Created scripts/codex_validation_batch_008.py.
 
 ### Batch 009 – JSON API Endpoints
 
-Added `/api/quests.json` and `/api/professions.json` to expose the processed quest and profession data. These endpoints are hidden from navigation and search results via `eleventyExcludeFromCollections`.
-
-Provided sample `fetch` usage in the README.
+Added `/api/quests.json` and `/api/professions.json` to expose the processed quest and profession data. A new section in the README explains how to `fetch` these endpoints. Both routes are hidden from navigation and search results via `eleventyExcludeFromCollections`.
 
 ### Batch 010 – Codex Compatibility Updates
 


### PR DESCRIPTION
## Summary
- document programmatic JSON API endpoints in the README
- mention README addition in batch summary

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889163c2e248331bf52f3a7290ed552