### PR TITLE
Add static pages and global footer

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,0 +1,9 @@
+<footer class="site-footer">
+  <p>
+    &copy; 2025 Galactic Archives |
+    <a href="/mission/">Mission</a> |
+    <a href="/what-is-this-site/">What is this site?</a> |
+    <a href="/privacy-policy/">Privacy Policy</a> |
+    <a href="/terms-of-use/">Terms of Use</a>
+  </p>
+</footer>

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -23,5 +23,6 @@
         </article>
       </main>
     </div>
+    {% include "footer.njk" %}
   </body>
 </html>

--- a/src/layouts/homepage.njk
+++ b/src/layouts/homepage.njk
@@ -28,5 +28,6 @@
         </ul>
       </main>
     </div>
+    {% include "footer.njk" %}
   </body>
 </html>

--- a/src/layouts/internal.njk
+++ b/src/layouts/internal.njk
@@ -24,5 +24,6 @@
         </article>
       </main>
     </div>
+    {% include "footer.njk" %}
   </body>
 </html>

--- a/src/layouts/static.njk
+++ b/src/layouts/static.njk
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include "head.njk" %}
+  </head>
+  <body>
+    <div class="layout">
+      {% include "sidebar.njk" %}
+      <main class="content">
+        <h1>{{ title }}</h1>
+        <article class="page-body">
+          {{ content | safe }}
+        </article>
+      </main>
+    </div>
+    {% include "footer.njk" %}
+  </body>
+</html>

--- a/src/pages/mission.md
+++ b/src/pages/mission.md
@@ -1,0 +1,9 @@
+---
+layout: static.njk
+permalink: /mission/
+title: Mission
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+Our mission is to centralize Star Wars Galaxies knowledge and preserve community history. Everyone is invited to contribute their expertise.

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -1,0 +1,9 @@
+---
+layout: static.njk
+permalink: /privacy-policy/
+title: Privacy Policy
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+We do not collect personal data. Basic server logs may record anonymous usage statistics for debugging purposes. This site is static and uses no tracking cookies.

--- a/src/pages/terms-of-use.md
+++ b/src/pages/terms-of-use.md
@@ -1,0 +1,9 @@
+---
+layout: static.njk
+permalink: /terms-of-use/
+title: Terms of Use
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+By accessing the Galactic Archives you agree that all information is provided "as is" with no warranty. This fan project has no affiliation with Lucasfilm or Disney.

--- a/src/pages/what-is-this-site.md
+++ b/src/pages/what-is-this-site.md
@@ -1,0 +1,9 @@
+---
+layout: static.njk
+permalink: /what-is-this-site/
+title: What Is This Site?
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+Galactic Archives combines community-created guides with original research curated by The Eye of the Galactic Beholder. It exists to catalog every corner of SWG for posterity.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -168,3 +168,19 @@ a:hover {
   font-weight: bold;
   display: block;
 }
+
+.site-footer {
+  background-color: #1a1a1a;
+  color: #ccc;
+  padding: 1rem;
+  text-align: center;
+  border-top: 1px solid #333;
+}
+
+.site-footer a {
+  color: #80dfff;
+}
+
+.site-footer a:hover {
+  text-decoration: underline;
+}

--- a/tests/layouts.test.js
+++ b/tests/layouts.test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import matter from 'gray-matter';
 
 // Ensure categories layout includes searchbox and breadcrumbs partials
 // to verify that common components are rendered.
@@ -16,4 +17,28 @@ test('homepage layout includes sidebar, head partials and category grid', () => 
   expect(tpl).toMatch('sidebar.njk');
   // Verify the layout loops through categories
   expect(tpl).toMatch('category-grid');
+});
+
+// Footer should be included in all primary layouts
+test('layouts include footer partial', () => {
+  const baseTpl = fs.readFileSync('src/layouts/base.njk', 'utf8');
+  const homeTpl = fs.readFileSync('src/layouts/homepage.njk', 'utf8');
+  const internalTpl = fs.readFileSync('src/layouts/internal.njk', 'utf8');
+  expect(baseTpl).toMatch('footer.njk');
+  expect(homeTpl).toMatch('footer.njk');
+  expect(internalTpl).toMatch('footer.njk');
+});
+
+// The static pages should use the new layout and parse correctly
+test('static pages render with static layout', () => {
+  const files = [
+    'src/pages/privacy-policy.md',
+    'src/pages/terms-of-use.md',
+    'src/pages/mission.md',
+    'src/pages/what-is-this-site.md'
+  ];
+  files.forEach((file) => {
+    const { data } = matter(fs.readFileSync(file, 'utf8'));
+    expect(data.layout).toBe('static.njk');
+  });
 });


### PR DESCRIPTION
## Summary
- add a new `static.njk` layout
- add footer partial and link it in all layouts
- create Privacy Policy, Terms of Use, Mission and What Is This Site pages
- style the footer in `main.css`
- test layout footer includes and page front matter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889190b395c8331b92db25c0aeb793d