### PR TITLE
Use dynamic year in footer

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,6 +1,6 @@
 <footer class="site-footer">
   <p>
-    &copy; 2025 Galactic Archives |
+    &copy; {{ "now" | date("yyyy") }} Galactic Archives |
     <a href="/mission/">Mission</a> |
     <a href="/what-is-this-site/">What is this site?</a> |
     <a href="/privacy-policy/">Privacy Policy</a> |


### PR DESCRIPTION
## Summary
- render the footer year dynamically via eleventy
- test the rendered footer year

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6889302aeb448331a65194b1a4893e40