### PR TITLE
Add macro for api JSON feeds

### DIFF
--- a/src/_includes/json-feed.njk
+++ b/src/_includes/json-feed.njk
@@ -1,0 +1,7 @@
+{% macro jsonFeed(collectionName) %}
+[
+{% for item in collections[collectionName] %}
+  {{ {"title": item.data.title, "category": item.data.category, "tags": item.data.tags, "url": item.url, "last_updated": item.data.last_updated} | json | safe }}{% if not loop.last %},{% endif %}
+{% endfor %}
+]
+{% endmacro %}

--- a/src/api/professions.json.njk
+++ b/src/api/professions.json.njk
@@ -2,8 +2,6 @@
 permalink: /api/professions.json
 eleventyExcludeFromCollections: true
 ---
-[
-{% for item in collections.professions %}
-  {{ {"title": item.data.title, "category": item.data.category, "tags": item.data.tags, "url": item.url, "last_updated": item.data.last_updated} | json | safe }}{% if not loop.last %},{% endif %}
-{% endfor %}
-]
+{% from "../_includes/json-feed.njk" import jsonFeed %}
+{{ jsonFeed("professions") }}
+

--- a/src/api/quests.json.njk
+++ b/src/api/quests.json.njk
@@ -2,8 +2,6 @@
 permalink: /api/quests.json
 eleventyExcludeFromCollections: true
 ---
-[
-{% for item in collections.quests %}
-  {{ {"title": item.data.title, "category": item.data.category, "tags": item.data.tags, "url": item.url, "last_updated": item.data.last_updated} | json | safe }}{% if not loop.last %},{% endif %}
-{% endfor %}
-]
+{% from "../_includes/json-feed.njk" import jsonFeed %}
+{{ jsonFeed("quests") }}
+

--- a/tests/apiTemplates.test.js
+++ b/tests/apiTemplates.test.js
@@ -3,16 +3,12 @@ import nunjucks from 'nunjucks';
 import fs from 'fs';
 import eleventyConfigFn, { slugifyCategory } from '../.eleventy.js';
 
-class NullLoader extends nunjucks.Loader {
-  getSource(name) {
-    return { src: '', path: name, noCache: true };
-  }
-}
 
 function renderTemplate(templatePath, context) {
   const tpl = fs.readFileSync(templatePath, 'utf8');
   const content = tpl.split('---').slice(2).join('---').trim();
-  const env = new nunjucks.Environment(new NullLoader());
+  const loader = new nunjucks.FileSystemLoader('src/_includes');
+  const env = new nunjucks.Environment(loader);
   if (context.jsonFilter) {
     env.addFilter('json', context.jsonFilter);
   }

--- a/tests/jsonTemplates.test.js
+++ b/tests/jsonTemplates.test.js
@@ -3,16 +3,12 @@ import nunjucks from 'nunjucks';
 import fs from 'fs';
 import eleventyConfigFn from '../.eleventy.js';
 
-class NullLoader extends nunjucks.Loader {
-  getSource(name) {
-    return { src: '', path: name, noCache: true };
-  }
-}
 
 function renderTemplate(templatePath, context) {
   const tpl = fs.readFileSync(templatePath, 'utf8');
   const content = tpl.split('---').slice(2).join('---').trim();
-  const env = new nunjucks.Environment(new NullLoader());
+  const loader = new nunjucks.FileSystemLoader('src/_includes');
+  const env = new nunjucks.Environment(loader);
   if (context.jsonFilter) {
     env.addFilter('json', context.jsonFilter);
   }


### PR DESCRIPTION
## Summary
- add jsonFeed macro for rendering collections as JSON
- refactor quests and professions API templates to use the macro
- update tests to load templates using FileSystemLoader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688932cee1308331a3a089b4f03f74d3