### PR TITLE
Add API frontmatter test

### DIFF
--- a/tests/apiTemplates.test.js
+++ b/tests/apiTemplates.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import nunjucks from 'nunjucks';
 import fs from 'fs';
+import matter from 'gray-matter';
 import eleventyConfigFn, { slugifyCategory } from '../.eleventy.js';
 
 
@@ -85,4 +86,12 @@ test('professions and quests API templates render valid JSON arrays', () => {
     expect(obj).toHaveProperty('url');
     expect(obj).toHaveProperty('last_updated');
   });
+});
+
+test('API templates exclude themselves from collections via front matter', () => {
+  const profMatter = matter(fs.readFileSync('src/api/professions.json.njk', 'utf8'));
+  const questMatter = matter(fs.readFileSync('src/api/quests.json.njk', 'utf8'));
+
+  expect(profMatter.data.eleventyExcludeFromCollections).toBe(true);
+  expect(questMatter.data.eleventyExcludeFromCollections).toBe(true);
 });


### PR DESCRIPTION
## Summary
- ensure API JSON templates exclude themselves from Eleventy collections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889346ab2f88331ae881f7bb994421c