### PR TITLE
Add API index documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Eleventy scans every Markdown file for a `category` value in its front matter an
 
 ## JSON API
 
-Use the following endpoints to access the raw Profession and Quest data generated for the site:
+Use the following endpoints to access the raw Profession and Quest data generated for the site.
+See the [JSON API overview](src/api/index.md) for details on each endpoint:
 
 - `/api/professions.json`
 - `/api/quests.json`

--- a/src/api/index.md
+++ b/src/api/index.md
@@ -1,0 +1,18 @@
+---
+layout: base.njk
+title: JSON API
+category: Meta
+tags:
+  - api
+  - overview
+last_updated: 2025-07-27
+---
+
+The Galactic Archives exposes a small JSON API for programmatic access to select site data. Each endpoint returns an array of objects used to build the related pages.
+
+## Available Endpoints
+
+- [/api/professions.json](/api/professions.json) - Raw profession metadata including title, category, tags, URL, and last updated date.
+- [/api/quests.json](/api/quests.json) - Processed quest information with the same fields as above.
+
+These files are generated at build time and excluded from navigation and search results.


### PR DESCRIPTION
## Summary
- document all JSON API endpoints in `src/api/index.md`
- link README JSON API section to the new page

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889352f31a88331808513aef6473428