### PR TITLE
Add Eleventy date filter and test

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 import { globSync } from "glob";
 import fs from "fs";
 import matter from "gray-matter";
+import { DateTime } from "luxon";
 
 function slugifyCategory(name) {
   return name
@@ -15,6 +16,9 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addFilter("json", (value) => JSON.stringify(value));
   eleventyConfig.addFilter("categorySlug", slugifyCategory);
+  eleventyConfig.addFilter("date", (value, format) =>
+    DateTime.fromJSDate(value === "now" ? new Date() : new Date(value)).toFormat(format)
+  );
 
   // Discover unique categories by scanning content files
   const files = globSync("src/**/*.md", {

--- a/tests/dateFilter.test.js
+++ b/tests/dateFilter.test.js
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+import eleventyConfigFn from '../.eleventy.js';
+
+test('date filter is registered', () => {
+  const mockConfig = {
+    addPassthroughCopy: jest.fn(),
+    addFilter: jest.fn(),
+    addCollection: jest.fn(),
+  };
+
+  eleventyConfigFn(mockConfig);
+  expect(mockConfig.addFilter).toHaveBeenCalledWith('date', expect.any(Function));
+});


### PR DESCRIPTION
## Summary
- add `DateTime` import
- register a new `date` filter in `.eleventy.js`
- add tests ensuring the `date` filter is configured

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68893c8996f88331aa56e9cfedd7ff3f