### PR TITLE
Add community & help pages

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,9 +1,11 @@
 <footer class="site-footer">
+  <p>&copy; {{ "now" | date("yyyy") }} Galactic Archives. Built by R21 Digital.</p>
   <p>
-    &copy; {{ "now" | date("yyyy") }} Galactic Archives |
-    <a href="/mission/">Mission</a> |
-    <a href="/what-is-this-site/">What is this site?</a> |
-    <a href="/privacy-policy/">Privacy Policy</a> |
-    <a href="/terms-of-use/">Terms of Use</a>
+    <a href="/privacy-policy/">Privacy Policy</a> •
+    <a href="/terms-of-use/">Terms of Use</a> •
+    <a href="/mission/">Mission</a> •
+    <a href="/what-is-this-site/">About</a> •
+    <a href="/help/">Help</a> •
+    <a href="/community/">Community</a>
   </p>
 </footer>

--- a/src/pages/community-standards.md
+++ b/src/pages/community-standards.md
@@ -1,0 +1,18 @@
+---
+layout: static.njk
+permalink: /community-standards/
+title: Community Standards
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+## Community Standards
+
+To maintain a positive experience, all users are expected to follow these basic principles:
+
+1. Be respectful and constructive.
+2. Avoid toxic behavior, harassment, or spam.
+3. Credit original sources and contributors when sharing guides or media.
+4. Use inclusive and welcoming language.
+
+Content violating these standards may be removed, and repeat violations may result in access restrictions.

--- a/src/pages/community.md
+++ b/src/pages/community.md
@@ -1,0 +1,20 @@
+---
+layout: static.njk
+permalink: /community/
+title: Join the Community
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+## Connect With Us
+
+The Galactic Archives community lives on Discord, where you can:
+
+- Suggest new content
+- Report site issues
+- Share builds, tips, or collections
+- Ask questions about the game
+
+[Join Our Discord](https://discord.gg/YOUR-DISCORD-CODE)
+
+We're also exploring future forums and events.

--- a/src/pages/help.md
+++ b/src/pages/help.md
@@ -1,0 +1,19 @@
+---
+layout: static.njk
+permalink: /help/
+title: Help
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+## Need Help?
+
+If you’re new to the site or to Star Wars Galaxies, here are a few helpful links:
+
+- [What is This Site?](/what-is-this-site/)
+- [Mission Statement](/mission/)
+- [Patch Notes](/patch-notes/) *(coming soon)*
+- [Join the Community](/community/)
+- Use the search bar at the top of any page to find quests, professions, planets, and more.
+
+If you're reporting an error or broken page, please contact our admin team via Discord.

--- a/tests/layouts.test.js
+++ b/tests/layouts.test.js
@@ -42,7 +42,10 @@ test('static pages render with static layout', () => {
     'src/pages/privacy-policy.md',
     'src/pages/terms-of-use.md',
     'src/pages/mission.md',
-    'src/pages/what-is-this-site.md'
+    'src/pages/what-is-this-site.md',
+    'src/pages/help.md',
+    'src/pages/community-standards.md',
+    'src/pages/community.md'
   ];
   files.forEach((file) => {
     const { data } = matter(fs.readFileSync(file, 'utf8'));


### PR DESCRIPTION
## Summary
- create new `/help/`, `/community-standards/`, and `/community/` pages
- update site footer with links to the new pages
- check new pages in layout tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68893a68fe3c8331bc96ea78fe8be3c0