### PR TITLE
Fix Discord link to use environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@
 USE_OFFLINE_MODE=true
 WIKI_URL=https://swgr.org/wiki/special/activity/
 OUTPUT_PATH=./data/recent-activity.json
+# Discord invite code for the community page
+DISCORD_INVITE_CODE=YOUR-DISCORD-CODE

--- a/data/env.js
+++ b/data/env.js
@@ -1,0 +1,5 @@
+import 'dotenv/config';
+
+export default {
+  DISCORD_INVITE_CODE: process.env.DISCORD_INVITE_CODE,
+};

--- a/src/pages/community.md
+++ b/src/pages/community.md
@@ -15,6 +15,6 @@ The Galactic Archives community lives on Discord, where you can:
 - Share builds, tips, or collections
 - Ask questions about the game
 
-[Join Our Discord](https://discord.gg/YOUR-DISCORD-CODE)
+[Join Our Discord](https://discord.gg/{{ env.DISCORD_INVITE_CODE | default('YOUR-DISCORD-CODE') }})
 
 We're also exploring future forums and events.


### PR DESCRIPTION
## Summary
- allow Eleventy templates to load `.env` variables via `data/env.js`
- reference `DISCORD_INVITE_CODE` variable on the community page
- document new variable in `.env.example`

## Testing
- `pytest -q`
- `DISCORD_INVITE_CODE=abcd1234 npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68893f26a0f48331802cc9c39352ff13