### PR TITLE
Add patch notes page

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -3,6 +3,7 @@
   <p>
     <a href="/privacy-policy/">Privacy Policy</a> •
     <a href="/terms-of-use/">Terms of Use</a> •
+    <a href="/patch-notes/">Patch Notes</a> •
     <a href="/mission/">Mission</a> •
     <a href="/what-is-this-site/">About</a> •
     <a href="/help/">Help</a> •

--- a/src/pages/patch-notes.md
+++ b/src/pages/patch-notes.md
@@ -1,0 +1,11 @@
+---
+layout: static.njk
+permalink: /patch-notes/
+title: Patch Notes
+eleventyExcludeFromCollections: true
+last_updated: 2025-07-27
+---
+
+## Patch Notes
+
+This section is forthcoming. Check back soon for the latest updates.

--- a/tests/layouts.test.js
+++ b/tests/layouts.test.js
@@ -45,7 +45,8 @@ test('static pages render with static layout', () => {
     'src/pages/what-is-this-site.md',
     'src/pages/help.md',
     'src/pages/community-standards.md',
-    'src/pages/community.md'
+    'src/pages/community.md',
+    'src/pages/patch-notes.md'
   ];
   files.forEach((file) => {
     const { data } = matter(fs.readFileSync(file, 'utf8'));


### PR DESCRIPTION
## Summary
- add placeholder page for `/patch-notes/`
- link patch notes from the footer
- update tests for new static page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889541a91748331bc65e520911044d3