### PR TITLE
Enable help and community pages in search

### DIFF
--- a/src/pages/community-standards.md
+++ b/src/pages/community-standards.md
@@ -2,7 +2,7 @@
 layout: static.njk
 permalink: /community-standards/
 title: Community Standards
-eleventyExcludeFromCollections: true
+category: Meta
 last_updated: 2025-07-27
 ---
 

--- a/src/pages/community.md
+++ b/src/pages/community.md
@@ -2,7 +2,7 @@
 layout: static.njk
 permalink: /community/
 title: Join the Community
-eleventyExcludeFromCollections: true
+category: Meta
 last_updated: 2025-07-27
 ---
 

--- a/src/pages/help.md
+++ b/src/pages/help.md
@@ -2,7 +2,7 @@
 layout: static.njk
 permalink: /help/
 title: Help
-eleventyExcludeFromCollections: true
+category: Meta
 last_updated: 2025-07-27
 ---
 


### PR DESCRIPTION
## Summary
- make `/help/`, `/community/`, and `/community-standards/` show up in the search index
- give them the `Meta` category so the Eleventy build works

## Testing
- `npm test`
- `pytest`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688954e7cea083319ca98ce908098ca6