### PR TITLE
Enforce semicolons in JS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,10 @@
   "env": {
     "node": true
   },
+  "rules": {
+    "semi": ["error", "always"],
+    "space-before-function-paren": ["error", "never"]
+  },
   "overrides": [
     {
       "files": ["src/**/*.js", "scripts/**/*.js"]

--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -1,29 +1,30 @@
-document.addEventListener("DOMContentLoaded", async () => {
+/* global Fuse */
+document.addEventListener('DOMContentLoaded', async() => {
   let pages;
   try {
-    const response = await fetch("/search-index.json");
+    const response = await fetch('/search-index.json');
     pages = await response.json();
   } catch (err) {
-    console.error("Failed to load search index:", err);
+    console.error('Failed to load search index:', err);
     return;
   }
 
   const fuse = new Fuse(pages, {
-    keys: ["title", "category", "tags"],
+    keys: ['title', 'category', 'tags'],
     threshold: 0.3
   });
 
-  const input = document.getElementById("search-input");
-  const resultsList = document.getElementById("search-results");
+  const input = document.getElementById('search-input');
+  const resultsList = document.getElementById('search-results');
 
-  input.addEventListener("input", () => {
+  input.addEventListener('input', () => {
     const query = input.value.trim();
-    resultsList.innerHTML = "";
+    resultsList.innerHTML = '';
 
     if (query.length > 1) {
       const results = fuse.search(query).slice(0, 10);
       results.forEach(({ item }) => {
-        const li = document.createElement("li");
+        const li = document.createElement('li');
         li.innerHTML = `<a href="${item.url}">${item.title}</a>`;
         resultsList.appendChild(li);
       });


### PR DESCRIPTION
## Summary
- keep semicolons consistent with existing code
- declare `Fuse` global and switch to single quotes in search.js

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68895d49d3fc833186cb97deaa3d39bd