### PR TITLE
Update README with .env guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ You can also install the Python packages via `make deps`.
 
 These steps are required prior to using `npm test` or `pytest`.
 
+## Environment File
+
+Copy `.env.example` to `.env` and adjust the values as needed. The file
+defines environment variables used by scripts and the site itself. For
+instance, `DISCORD_INVITE_CODE` controls the invite link shown on
+`/community/`:
+
+```bash
+DISCORD_INVITE_CODE=YOUR-DISCORD-CODE
+```
+
 ## Data Import
 
 The `/scripts` folder contains scrapers to pull data from:


### PR DESCRIPTION
## Summary
- document how to create `.env` from `.env.example`
- explain that `DISCORD_INVITE_CODE` changes the `/community/` invite link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68897a5b04448331b53ea1b988a44d48