### PR TITLE
Update listing pages to use layout

### DIFF
--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -5,27 +5,14 @@ pagination:
   alias: posts
 permalink: "/blog/"
 eleventyExcludeFromCollections: true
+layout: static.njk
 ---
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    {% include "head.njk" %}
-  </head>
-  <body>
-    <div class="layout">
-      {% include "sidebar.njk" %}
-      <main class="content">
-        <h1>Blog</h1>
-        <ul class="category-list">
-          {% for post in posts | sort(attribute='date') | reverse %}
-            <li>
-              <a href="{{ post.url }}">{{ post.data.title }}</a>
-              <span class="tag">{{ post.data.date | date('yyyy-MM-dd') }}</span>
-            </li>
-          {% endfor %}
-        </ul>
-      </main>
-    </div>
-    {% include "footer.njk" %}
-  </body>
-</html>
+<h1>Blog</h1>
+<ul class="category-list">
+  {% for post in posts | sort(attribute='date') | reverse %}
+    <li>
+      <a href="{{ post.url }}">{{ post.data.title }}</a>
+      <span class="tag">{{ post.data.date | date('yyyy-MM-dd') }}</span>
+    </li>
+  {% endfor %}
+</ul>

--- a/src/patch-notes/index.njk
+++ b/src/patch-notes/index.njk
@@ -5,27 +5,14 @@ pagination:
   alias: notes
 permalink: "/patch-notes/"
 eleventyExcludeFromCollections: true
+layout: static.njk
 ---
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    {% include "head.njk" %}
-  </head>
-  <body>
-    <div class="layout">
-      {% include "sidebar.njk" %}
-      <main class="content">
-        <h1>Patch Notes</h1>
-        <ul class="category-list">
-          {% for note in notes | sort(attribute='date') | reverse %}
-            <li>
-              <a href="{{ note.url }}">{{ note.data.title }}</a>
-              <span class="tag">{{ note.data.date | date('yyyy-MM-dd') }}</span>
-            </li>
-          {% endfor %}
-        </ul>
-      </main>
-    </div>
-    {% include "footer.njk" %}
-  </body>
-</html>
+<h1>Patch Notes</h1>
+<ul class="category-list">
+  {% for note in notes | sort(attribute='date') | reverse %}
+    <li>
+      <a href="{{ note.url }}">{{ note.data.title }}</a>
+      <span class="tag">{{ note.data.date | date('yyyy-MM-dd') }}</span>
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- declare `static.njk` layout for blog and patch-notes
- strip duplicated HTML wrappers from listing templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68897a6991248331b8f72b384ca2d3cf