### PR TITLE
Handle pages without category in sidebar

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,8 @@ import matter from "gray-matter";
 import { DateTime } from "luxon";
 
 function slugifyCategory(name) {
-  return name
+  if (!name) return '';
+  return String(name)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '');

--- a/src/_includes/sidebar.njk
+++ b/src/_includes/sidebar.njk
@@ -2,7 +2,7 @@
   <h2>Navigation</h2>
   {% set lastCategory = null %}
   {% for page in collections.all | sort(attribute='data.category') %}
-    {% if not page.data.eleventyExcludeFromCollections %}
+    {% if page.data.category and not page.data.eleventyExcludeFromCollections %}
       {% if page.data.category != lastCategory %}
         {% if lastCategory %}
           </ul>

--- a/tests/sidebar.test.js
+++ b/tests/sidebar.test.js
@@ -1,0 +1,25 @@
+import nunjucks from 'nunjucks';
+import fs from 'fs';
+import { slugifyCategory } from '../.eleventy.js';
+
+class NullLoader extends nunjucks.Loader {
+  getSource(name) {
+    return { src: '', path: name, noCache: true };
+  }
+}
+
+test('sidebar renders when a page lacks category', () => {
+  const tpl = fs.readFileSync('src/_includes/sidebar.njk', 'utf8');
+  const env = new nunjucks.Environment(new NullLoader());
+  env.addFilter('categorySlug', slugifyCategory);
+  const html = env.renderString(tpl, {
+    collections: {
+      all: [
+        { data: { category: 'Guides', title: 'With Category' }, url: '/guides/with-category/' },
+        { data: { title: 'No Category' }, url: '/no-category/' }
+      ]
+    }
+  });
+  expect(html).toContain('With Category');
+  expect(html).not.toContain('No Category');
+});


### PR DESCRIPTION
## Summary
- skip pages without a `category` when rendering the sidebar
- guard `slugifyCategory` against falsy input
- add regression test for sidebar rendering

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6889879c05fc8331ab2d0513fbe684e1