### PR TITLE
Add Eleventy build test with uncategorized pages

### DIFF
--- a/src/uncategorized/another-no-category.md
+++ b/src/uncategorized/another-no-category.md
@@ -1,0 +1,8 @@
+---
+layout: static.njk
+title: Another No Category
+permalink: /another-no-category/
+last_updated: 2025-07-28
+---
+
+Another sample without a category.

--- a/src/uncategorized/no-category-page.md
+++ b/src/uncategorized/no-category-page.md
@@ -1,0 +1,8 @@
+---
+layout: static.njk
+title: No Category Page
+permalink: /no-category-page/
+last_updated: 2025-07-28
+---
+
+This is a sample page without a category.

--- a/tests/eleventyBuild.test.js
+++ b/tests/eleventyBuild.test.js
@@ -1,0 +1,12 @@
+import Eleventy from '@11ty/eleventy';
+import fs from 'fs';
+
+// Basic smoke test to ensure the Eleventy build succeeds
+// when pages lack a `category` front matter value.
+
+test('eleventy build completes without errors', async () => {
+  const elev = new Eleventy('.', 'test-dist', { configPath: '.eleventy.js' });
+  await elev.init();
+  await expect(elev.write()).resolves.toBeDefined();
+  fs.rmSync('test-dist', { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add uncategorized sample pages
- smoke test Eleventy by running a full build

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68898f85ce2883318a55a641747d1039