### PR TITLE
Add Lunr powered search page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -82,6 +82,8 @@ export default function (eleventyConfig) {
   // is generated from that directory rather than `public`.
   eleventyConfig.addPassthroughCopy({ "src/styles": "styles" });
   eleventyConfig.addPassthroughCopy({ "src/scripts": "scripts" });
+  // Ensure the search index JSON is available in the output
+  eleventyConfig.addPassthroughCopy("search-index.json");
 
   return {
     dir: {

--- a/src/_data/searchIndex.js
+++ b/src/_data/searchIndex.js
@@ -1,0 +1,39 @@
+import { globSync } from 'glob';
+import fs from 'fs';
+import matter from 'gray-matter';
+
+export default function () {
+  const files = globSync('src/**/*.md', {
+    ignore: [
+      'src/_includes/**',
+      'src/layouts/**',
+      'src/styles/**',
+      'src/scripts/**',
+      'src/internal/**'
+    ]
+  });
+
+  const index = [];
+  for (const file of files) {
+    const fileContents = fs.readFileSync(file, 'utf-8');
+    const { data, content } = matter(fileContents);
+    if (data.eleventyExcludeFromCollections) continue;
+
+    const relative = file
+      .replace(/^src\//, '')
+      .replace(/index\.md$/, '')
+      .replace(/\.md$/, '');
+    const url = data.permalink || `/${relative}/`;
+
+    index.push({
+      title: data.title || '',
+      category: data.category,
+      tags: data.tags,
+      url,
+      last_updated: data.last_updated,
+      content
+    });
+  }
+
+  return index;
+}

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -2,5 +2,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>{{ title }} | Galactic Archives</title>
 <link rel="stylesheet" href="/styles/main.css" />
-<script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
+<link rel="search" href="/search/" />
+<script src="https://cdn.jsdelivr.net/npm/lunr/lunr.min.js"></script>
 <script defer src="/scripts/search.js"></script>

--- a/src/pages/search.md
+++ b/src/pages/search.md
@@ -1,0 +1,10 @@
+---
+title: Search
+layout: static.njk
+permalink: /search/
+---
+
+<div class="search-container">
+  <input type="text" id="search-input" placeholder="Search Galactic Archives..." autocomplete="off" />
+  <ul id="search-results"></ul>
+</div>

--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -1,32 +1,43 @@
-/* global Fuse */
-document.addEventListener('DOMContentLoaded', async() => {
+/* global lunr */
+
+document.addEventListener('DOMContentLoaded', async () => {
   let pages;
   try {
-    const response = await fetch('/search-index.json');
-    pages = await response.json();
+    const res = await fetch('/search-index.json');
+    pages = await res.json();
   } catch (err) {
     console.error('Failed to load search index:', err);
     return;
   }
 
-  const fuse = new Fuse(pages, {
-    keys: ['title', 'category', 'tags'],
-    threshold: 0.3
+  const idx = lunr(function () {
+    this.ref('url');
+    this.field('title');
+    this.field('category');
+    this.field('tags');
+    this.field('content');
+
+    pages.forEach(page => this.add(page));
   });
 
   const input = document.getElementById('search-input');
   const resultsList = document.getElementById('search-results');
+
+  if (!input) return;
 
   input.addEventListener('input', () => {
     const query = input.value.trim();
     resultsList.innerHTML = '';
 
     if (query.length > 1) {
-      const results = fuse.search(query).slice(0, 10);
-      results.forEach(({ item }) => {
-        const li = document.createElement('li');
-        li.innerHTML = `<a href="${item.url}">${item.title}</a>`;
-        resultsList.appendChild(li);
+      const results = idx.search(query).slice(0, 10);
+      results.forEach(({ ref }) => {
+        const page = pages.find(p => p.url === ref);
+        if (page) {
+          const li = document.createElement('li');
+          li.innerHTML = `<a href="${page.url}">${page.title}</a>`;
+          resultsList.appendChild(li);
+        }
       });
     }
   });


### PR DESCRIPTION
## Summary
- add dedicated search page
- generate searchIndex data
- integrate Lunr search client
- expose search index via passthrough
- link search page from head include

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6889a97993048331bf99d376c4661096