### PR TITLE
Implement SEO metadata and sitemap

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -84,6 +84,8 @@ export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "src/scripts": "scripts" });
   // Ensure the search index JSON is available in the output
   eleventyConfig.addPassthroughCopy("search-index.json");
+  // Expose generated sitemap
+  eleventyConfig.addPassthroughCopy("sitemap.xml");
 
   return {
     dir: {

--- a/README.md
+++ b/README.md
@@ -173,3 +173,10 @@ fetch('/api/professions.json')
   .then(res => res.json())
   .then(data => console.log(data));
 ```
+
+## SEO & Sitemap
+
+Global site details like the name, base URL and description live in
+`src/_data/metadata.js`. These values populate the `seo.njk` partial which
+generates meta tags for each page. A sitemap is built from `collections.all`
+and written to `/sitemap.xml` during the Eleventy build.

--- a/docs/batch_summary.md
+++ b/docs/batch_summary.md
@@ -96,3 +96,10 @@ Introduced a `/patch-notes/` route for release notes. These Markdown files use t
 ### Batch 013 – Community & Help Pages
 
 Added /help/, /community-standards/, and /community/ pages for site guidance and community engagement. Updated the footer with new links and improved styling.
+
+### Batch 015 – SEO Metadata & Sitemap
+
+Added metadata.js for global site information.
+Created seo.njk partial for meta tags and updated head.njk to include it.
+Implemented sitemap.xml generation using collections.all and updated Eleventy config to pass it through.
+

--- a/src/_data/metadata.js
+++ b/src/_data/metadata.js
@@ -1,0 +1,6 @@
+export default {
+  siteName: 'Galactic Archives',
+  siteUrl: 'https://example.com',
+  siteDescription: 'A unified Star Wars Galaxies knowledge hub.',
+  siteImage: '/images/og-image.png'
+};

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -1,6 +1,6 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>{{ title }} | Galactic Archives</title>
+{% include "seo.njk" %}
 <link rel="stylesheet" href="/styles/main.css" />
 <link rel="search" href="/search/" />
 <script src="https://cdn.jsdelivr.net/npm/lunr/lunr.min.js"></script>

--- a/src/_includes/seo.njk
+++ b/src/_includes/seo.njk
@@ -1,0 +1,17 @@
+{% set metaDesc = description or metadata.siteDescription %}
+<title>{{ title }} | {{ metadata.siteName }}</title>
+<meta name="description" content="{{ metaDesc }}" />
+<link rel="canonical" href="{{ metadata.siteUrl }}{{ page.url }}" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="{{ title }} | {{ metadata.siteName }}" />
+<meta property="og:description" content="{{ metaDesc }}" />
+<meta property="og:url" content="{{ metadata.siteUrl }}{{ page.url }}" />
+{% if metadata.siteImage %}
+<meta property="og:image" content="{{ metadata.siteImage }}" />
+{% endif %}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{ title }} | {{ metadata.siteName }}" />
+<meta name="twitter:description" content="{{ metaDesc }}" />
+{% if metadata.siteImage %}
+<meta name="twitter:image" content="{{ metadata.siteImage }}" />
+{% endif %}

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -1,0 +1,14 @@
+---
+permalink: sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for item in collections.all %}
+{% if item.data.eleventyExcludeFromCollections != true %}
+  <url>
+    <loc>{{ metadata.siteUrl }}{{ item.url }}</loc>
+  </url>
+{% endif %}
+{% endfor %}
+</urlset>

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -1,0 +1,43 @@
+import nunjucks from 'nunjucks';
+import fs from 'fs';
+import matter from 'gray-matter';
+
+class NullLoader extends nunjucks.Loader {
+  getSource(name) {
+    return { src: '', path: name, noCache: true };
+  }
+}
+
+test('seo partial outputs default meta tags', () => {
+  const tpl = fs.readFileSync('src/_includes/seo.njk', 'utf8');
+  const env = new nunjucks.Environment(new NullLoader());
+  const html = env.renderString(tpl, {
+    metadata: {
+      siteName: 'Site',
+      siteUrl: 'https://example.com',
+      siteDescription: 'Desc',
+      siteImage: '/img.png'
+    },
+    title: 'Home',
+    description: 'Custom',
+    page: { url: '/' }
+  });
+  expect(html).toContain('<title>Home | Site</title>');
+  expect(html).toContain('meta name="description"');
+  expect(html).toContain('og:title');
+  expect(html).toContain('twitter:card');
+});
+
+test('sitemap template lists provided pages', () => {
+  const file = fs.readFileSync('src/sitemap.xml.njk', 'utf8');
+  const { data, content } = matter(file);
+  expect(data.eleventyExcludeFromCollections).toBe(true);
+  const env = new nunjucks.Environment(new NullLoader());
+  const xml = env.renderString(content, {
+    collections: {
+      all: [ { url: '/page-one/', data: {} } ]
+    },
+    metadata: { siteUrl: 'https://example.com' }
+  });
+  expect(xml).toContain('<loc>https://example.com/page-one/</loc>');
+});


### PR DESCRIPTION
## Summary
- add global metadata object
- add SEO partial and update head include
- expose sitemap template and passthrough in Eleventy
- document new metadata and sitemap functionality
- test SEO meta tags and sitemap output

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889b114bacc8331841d602730148596