### PR TITLE
Update search index generation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -56,20 +56,6 @@ export default function (eleventyConfig) {
     );
   }
 
-    eleventyConfig.addCollection("searchIndex", function (collectionApi) {
-      return collectionApi
-        .getAll()
-        .filter((item) => item.data.eleventyExcludeFromCollections !== true)
-        .map((item) => {
-          return {
-            title: item.data.title,
-            category: item.data.category,
-            tags: item.data.tags,
-            url: item.url,
-            last_updated: item.data.last_updated,
-          };
-        });
-    });
 
     eleventyConfig.addCollection("blog", (c) =>
       c.getFilteredByGlob("src/blog/*.md")
@@ -82,8 +68,6 @@ export default function (eleventyConfig) {
   // is generated from that directory rather than `public`.
   eleventyConfig.addPassthroughCopy({ "src/styles": "styles" });
   eleventyConfig.addPassthroughCopy({ "src/scripts": "scripts" });
-  // Ensure the search index JSON is available in the output
-  eleventyConfig.addPassthroughCopy("search-index.json");
   // Expose generated sitemap
   eleventyConfig.addPassthroughCopy("sitemap.xml");
 

--- a/src/search-index.json.njk
+++ b/src/search-index.json.njk
@@ -3,7 +3,7 @@ permalink: search-index.json
 eleventyExcludeFromCollections: true
 ---
 [
-{% for item in collections.searchIndex %}
+{% for item in searchIndex %}
   {{ item | json | safe }}{% if not loop.last %},{% endif %}
 {% endfor %}
 ]

--- a/tests/jsonTemplates.test.js
+++ b/tests/jsonTemplates.test.js
@@ -16,47 +16,39 @@ function renderTemplate(templatePath, context) {
 }
 
 test('search-index template renders valid JSON array', () => {
-  const collections = {};
   let jsonFilter;
   const mockConfig = {
     addPassthroughCopy: jest.fn(),
     addFilter: (name, fn) => {
       if (name === 'json') jsonFilter = fn;
     },
-    addCollection: (name, fn) => {
-      collections[name] = fn;
-    },
+    addCollection: jest.fn(),
   };
 
-  // Register collections and filters
+  // Register filters
   eleventyConfigFn(mockConfig);
 
-  const items = [
+  const searchIndex = [
     {
-      data: {
-        title: 'Page One',
-        category: 'Guides',
-        tags: ['intro'],
-        last_updated: '2025-07-27',
-      },
+      title: 'Page One',
+      category: 'Guides',
+      tags: ['intro'],
       url: '/page-one/',
+      last_updated: '2025-07-27',
+      content: 'foo',
     },
     {
-      data: {
-        title: 'Page Two',
-        category: 'Planets',
-        tags: ['outdoor'],
-        last_updated: '2025-07-26',
-      },
+      title: 'Page Two',
+      category: 'Planets',
+      tags: ['outdoor'],
       url: '/page-two/',
+      last_updated: '2025-07-26',
+      content: 'bar',
     },
   ];
 
-  const collectionApi = { getAll: () => items };
-  const searchIndex = collections['searchIndex'](collectionApi);
-
   const rendered = renderTemplate('src/search-index.json.njk', {
-    collections: { searchIndex },
+    searchIndex,
     jsonFilter,
   });
 
@@ -68,6 +60,7 @@ test('search-index template renders valid JSON array', () => {
     expect(obj).toHaveProperty('tags');
     expect(obj).toHaveProperty('url');
     expect(obj).toHaveProperty('last_updated');
+    expect(obj).toHaveProperty('content');
   });
 });
 
@@ -152,6 +145,7 @@ test('search-index template parses mock collection data correctly', () => {
       tags: ['intro'],
       url: '/item-a/',
       last_updated: '2025-07-20',
+      content: 'A',
     },
     {
       title: 'Item B',
@@ -159,11 +153,12 @@ test('search-index template parses mock collection data correctly', () => {
       tags: ['explore'],
       url: '/item-b/',
       last_updated: '2025-07-21',
+      content: 'B',
     },
   ];
 
   const rendered = renderTemplate('src/search-index.json.njk', {
-    collections: { searchIndex: sampleIndex },
+    searchIndex: sampleIndex,
     jsonFilter: JSON.stringify,
   });
 
@@ -175,5 +170,6 @@ test('search-index template parses mock collection data correctly', () => {
     expect(obj).toHaveProperty('tags');
     expect(obj).toHaveProperty('url');
     expect(obj).toHaveProperty('last_updated');
+    expect(obj).toHaveProperty('content');
   });
 });


### PR DESCRIPTION
## Summary
- remove the `searchIndex` collection and passthrough copy from the Eleventy config
- update `search-index.json.njk` to use global `searchIndex` data
- adapt JSON template tests to expect the `content` field
- rewrite searchIndex tests for new global data generator

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6889b539b4b88331860c408263c6c179