### PR TITLE
Fix Eleventy data directory

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -76,7 +76,7 @@ export default function (eleventyConfig) {
       input: "src",
       includes: "_includes",
       layouts: "layouts",
-      data: "../data",
+      data: "_data",
       output: "dist"
     },
     markdownTemplateEngine: "njk",


### PR DESCRIPTION
## Summary
- use default `_data` location for Eleventy data directory

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6889bd5b36f08331932fe4667db07672