### PR TITLE
Fix seo image override

### DIFF
--- a/src/_includes/seo.njk
+++ b/src/_includes/seo.njk
@@ -1,4 +1,5 @@
 {% set metaDesc = description or metadata.siteDescription %}
+{% set previewImage = image or metadata.siteImage %}
 <title>{{ title }} | {{ metadata.siteName }}</title>
 <meta name="description" content="{{ metaDesc }}" />
 <link rel="canonical" href="{{ metadata.siteUrl }}{{ page.url }}" />
@@ -6,12 +7,12 @@
 <meta property="og:title" content="{{ title }} | {{ metadata.siteName }}" />
 <meta property="og:description" content="{{ metaDesc }}" />
 <meta property="og:url" content="{{ metadata.siteUrl }}{{ page.url }}" />
-{% if metadata.siteImage %}
-<meta property="og:image" content="{{ metadata.siteImage }}" />
+{% if previewImage %}
+<meta property="og:image" content="{{ previewImage }}" />
 {% endif %}
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{{ title }} | {{ metadata.siteName }}" />
 <meta name="twitter:description" content="{{ metaDesc }}" />
-{% if metadata.siteImage %}
-<meta name="twitter:image" content="{{ metadata.siteImage }}" />
+{% if previewImage %}
+<meta name="twitter:image" content="{{ previewImage }}" />
 {% endif %}

--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -28,6 +28,24 @@ test('seo partial outputs default meta tags', () => {
   expect(html).toContain('twitter:card');
 });
 
+test('seo partial uses provided image', () => {
+  const tpl = fs.readFileSync('src/_includes/seo.njk', 'utf8');
+  const env = new nunjucks.Environment(new NullLoader());
+  const html = env.renderString(tpl, {
+    metadata: {
+      siteName: 'Site',
+      siteUrl: 'https://example.com',
+      siteDescription: 'Desc',
+      siteImage: '/default.png'
+    },
+    title: 'Post',
+    image: '/custom.png',
+    page: { url: '/post/' }
+  });
+  expect(html).toContain('<meta property="og:image" content="/custom.png" />');
+  expect(html).toContain('<meta name="twitter:image" content="/custom.png" />');
+});
+
 test('sitemap template lists provided pages', () => {
   const file = fs.readFileSync('src/sitemap.xml.njk', 'utf8');
   const { data, content } = matter(file);


### PR DESCRIPTION
## Summary
- allow overriding OpenGraph and Twitter images
- test using custom images

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6889bf0d6b108331845b2406aa8d2797