### PR TITLE
Fix search snippet whitespace

### DIFF
--- a/src/_data/searchIndex.js
+++ b/src/_data/searchIndex.js
@@ -19,7 +19,7 @@ export default function() {
     const { data, content } = matter(fileContents);
     if (data.eleventyExcludeFromCollections) continue;
 
-    const snippet = content.slice(0, 1000);
+    const snippet = content.replace(/\n/g, ' ').slice(0, 1000);
 
     const relative = file
       .replace(/^src\//, '')


### PR DESCRIPTION
## Summary
- normalize whitespace in search index snippet generation

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889c3af4d78833186d5e3a4d6c39d9f