### PR TITLE
Update policy pages to use base layout

### DIFF
--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -1,11 +1,9 @@
 ---
-layout: static.njk
+layout: base.njk
 permalink: /privacy-policy/
 title: Privacy Policy
 eleventyExcludeFromCollections: true
 last_updated: 2025-07-27
 ---
 
-## Privacy Policy
-
-We do not collect personal data. Basic server logs may record anonymous usage statistics for debugging purposes. This site is static and uses no tracking cookies.
+Content coming soon.

--- a/src/pages/terms-of-use.md
+++ b/src/pages/terms-of-use.md
@@ -1,11 +1,9 @@
 ---
-layout: static.njk
-permalink: /terms-of-use/
+layout: base.njk
+permalink: /terms/
 title: Terms of Use
 eleventyExcludeFromCollections: true
 last_updated: 2025-07-27
 ---
 
-## Terms of Use
-
-By accessing the Galactic Archives you agree that all information is provided "as is" with no warranty. This fan project has no affiliation with Lucasfilm or Disney.
+Content coming soon.

--- a/tests/layouts.test.js
+++ b/tests/layouts.test.js
@@ -27,19 +27,20 @@ test('layouts include footer partial', () => {
 });
 
 // The static pages should use the new layout and parse correctly
-test('static pages render with static layout', () => {
-  const files = [
-    'src/pages/privacy-policy.md',
-    'src/pages/terms-of-use.md',
-    'src/pages/mission.md',
-    'src/pages/what-is-this-site.md',
-    'src/pages/help.md',
-    'src/pages/community-standards.md',
-    'src/pages/community.md'
-  ];
-  files.forEach((file) => {
+test('static pages render with correct layouts', () => {
+  const expectations = {
+    'src/pages/privacy-policy.md': 'base.njk',
+    'src/pages/terms-of-use.md': 'base.njk',
+    'src/pages/mission.md': 'static.njk',
+    'src/pages/what-is-this-site.md': 'static.njk',
+    'src/pages/help.md': 'static.njk',
+    'src/pages/community-standards.md': 'static.njk',
+    'src/pages/community.md': 'static.njk'
+  };
+
+  Object.entries(expectations).forEach(([file, layout]) => {
     const { data } = matter(fs.readFileSync(file, 'utf8'));
-    expect(data.layout).toBe('static.njk');
+    expect(data.layout).toBe(layout);
   });
 });
 


### PR DESCRIPTION
## Summary
- simplify privacy and terms pages with Batch 018 placeholder text
- swap to `base.njk` layout and adjust permalinks
- update layout tests to expect new layout assignments

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889c72d06e88331931ed5d8e8d3ed42